### PR TITLE
Split deploy scripts, allow datastore write.

### DIFF
--- a/frontend/deploy_dev.sh
+++ b/frontend/deploy_dev.sh
@@ -1,1 +1,1 @@
-npm start
+gcloud app deploy app.yaml --project=bboy-jam-dev-218006

--- a/frontend/deploy_local.sh
+++ b/frontend/deploy_local.sh
@@ -1,0 +1,1 @@
+npm start

--- a/sixstep/README.md
+++ b/sixstep/README.md
@@ -3,5 +3,10 @@
 # Run Locally
 dev_appserver.py app.yaml
 
+# Local Datastore Viewer
+When running locally, datastore uses a local file that persists between invocations of the local server. More info here: https://cloud.google.com/appengine/docs/standard/python/tools/using-local-server
+Access local datastore viewer here:
+http://localhost:8000/datastore
+
 # Deploy to gCloud
 gcloud app deploy

--- a/sixstep/deploy_dev.sh
+++ b/sixstep/deploy_dev.sh
@@ -1,1 +1,2 @@
-dev_appserver.py app_dev.yaml
+gcloud app deploy app_dev.yaml --project=bboy-jam-dev-218006
+

--- a/sixstep/deploy_local.sh
+++ b/sixstep/deploy_local.sh
@@ -1,0 +1,2 @@
+dev_appserver.py app_dev.yaml
+

--- a/sixstep/main.go
+++ b/sixstep/main.go
@@ -8,6 +8,9 @@ import (
 	"fmt"
 	"github.com/gorilla/mux"
 	"google.golang.org/appengine"
+	"google.golang.org/appengine/datastore"
+	"google.golang.org/appengine/log"
+
 	"net/http"
 	"os"
 )
@@ -17,6 +20,10 @@ const (
 )
 
 var router = mux.NewRouter()
+
+type User struct {
+	Name string
+}
 
 // Register router to work with AppEngine.
 func init() {
@@ -30,9 +37,16 @@ func main() {
 }
 
 func handle(w http.ResponseWriter, r *http.Request) {
+	ctx := appengine.NewContext(r)
+
 	// Example of getting env variable.
-	//ctx := appengine.NewContext(r)
-	//log.Infof(ctx, os.Getenv("CLIENT_URL"))
+	// log.Infof(ctx, os.Getenv("ALLOWED_ORIGIN"))
+
+	key := datastore.NewIncompleteKey(ctx, "User", nil)
+
+	if _, err := datastore.Put(ctx, key, &User{Name: "aoei"}); err != nil {
+		log.Errorf(ctx, "%v", err)
+	}
 
 	fmt.Fprintln(w, "Hello, bboy world!")
 }


### PR DESCRIPTION
Correctly split local and dev deploy scripts for front/backend.
Provided ability to write to datastore.